### PR TITLE
Fix remaining relative links that break in the portal renderer

### DIFF
--- a/docs/10-index.md
+++ b/docs/10-index.md
@@ -23,8 +23,8 @@ Please see the following specifications we have aligned with:
 
 ## Getting started
 
-We recommend that you start off by accessing our [Sandbox](./40-sandbox.md).
+We recommend that you start off by accessing our [Sandbox](/perry/developer/documentation?resource=euhub-zopa-portal&document=docs/40-sandbox.md).
 
 Our Sandbox fully reflects our production environment and provides an easy route to testing out your proposition.
 
-To access the production environment, you must be a TPP authorised by the FCA or passported into the UK. Instructions for accessing our Production APIs are [here](./30-production.md). Please email us on openbanking-support@zopa.com when you onboard so we can help with any issues and ensure you are notified about any updates to the API.
+To access the production environment, you must be a TPP authorised by the FCA or passported into the UK. Instructions for accessing our Production APIs are [here](/perry/developer/documentation?resource=euhub-zopa-portal&document=docs/30-production.md). Please email us on openbanking-support@zopa.com when you onboard so we can help with any issues and ensure you are notified about any updates to the API.

--- a/docs/Help/40-faqs.md
+++ b/docs/Help/40-faqs.md
@@ -34,9 +34,9 @@ A TPP, Third Party Provider, can perform the following roles once they are regis
 As a TPP, in order to access our Read/Write APIs, you need to be enrolled with Open Banking and registered with the Financial Conduct Authority (FCA) as an AISP. This will then enable you to access our APIs.
 
 ### As a Third Party Provider, is there somewhere I can test prototype Open Banking Solutions?
- Yes, Zopa has a test facility [Sandbox](../40-sandbox.md) available through our Developer Portal.
+ Yes, Zopa has a test facility [Sandbox](/perry/developer/documentation?resource=euhub-zopa-portal&document=docs/40-sandbox.md) available through our Developer Portal.
 
-Check out our [Production Environment](../30-production.md) guide for a step by step guide on how to start testing with our Sandbox APIs.
+Check out our [Production Environment](/perry/developer/documentation?resource=euhub-zopa-portal&document=docs/30-production.md) guide for a step by step guide on how to start testing with our Sandbox APIs.
 
 
 ### Where are the specifications you have used to build your current APIs?


### PR DESCRIPTION
Relative paths like ./40-sandbox.md resolve from the repo root in the portal, not from the file's location. Convert to full portal URLs to match the pattern used everywhere else in the repo.