### PR TITLE
Rewrite production page for clarity and remove repetition

### DIFF
--- a/docs/30-production.md
+++ b/docs/30-production.md
@@ -2,9 +2,11 @@
 
 ## OIDC Discovery
 
-The OIDC discovery documents describe the supported parameters for each environment:
-- Production: `https://auth1.openbanking.zopa.com/.well-known/openid-configuration`
-- Sandbox: `https://auth1.openbanking-sandbox.zopa.com/.well-known/openid-configuration`
+- Base URL: `https://auth1.openbanking.zopa.com/`
+- Discovery document: `https://auth1.openbanking.zopa.com/.well-known/openid-configuration`
+- Sandbox discovery document: `https://auth1.openbanking-sandbox.zopa.com/.well-known/openid-configuration`
+
+The discovery documents describe the supported parameters for each environment.
 
 Our production environment conforms to FAPI 1.0 Advanced. Sandbox offers less strict profiles to assist with integration testing — always verify your integration against the production discovery document before going live.
 

--- a/docs/30-production.md
+++ b/docs/30-production.md
@@ -1,26 +1,22 @@
 # Production
 
-## Authorisation Server URLs
-- OIDC Well Known endpoint: `https://auth1.openbanking.zopa.com/.well-known/openid-configuration`
-- baseUrl: `https://auth1.openbanking.zopa.com/`
+## OIDC Discovery
 
-## Authorisation URL
-
-The supported parameters differ between environments. Always check the OIDC discovery document for the environment you are targeting:
+The OIDC discovery documents describe the supported parameters for each environment:
 - Production: `https://auth1.openbanking.zopa.com/.well-known/openid-configuration`
 - Sandbox: `https://auth1.openbanking-sandbox.zopa.com/.well-known/openid-configuration`
 
-The one exception is the authorisation endpoint itself — rather than a single HTTPS endpoint, we use separate `zopa://` deeplinks per consent type as described below. This is not derivable from the discovery document.
+Our production environment conforms to FAPI 1.0 Advanced. Sandbox offers less strict profiles to assist with integration testing — always verify your integration against the production discovery document before going live.
 
-We currently only support redirect via a deeplink to the Zopa mobile app. Unlike most ASPSPs which use a standard HTTPS authorisation endpoint, our authorisation URLs use a custom `zopa://` deeplink scheme to redirect the PSU into the Zopa mobile app.
+## Authorisation URL
 
-> **Note:** The `/o3/v1.0/auth-code-url` endpoint is a convenience helper available on sandbox only to assist with testing. It builds the request object server-side using `alg=none` and **must not be used in production** — it does not support PS256 and will return a 500 error if attempted.
-
-The deeplink format differs by consent type:
+The authorisation endpoint is the one parameter that cannot be derived from the discovery document. Rather than a standard HTTPS endpoint, we use `zopa://` deeplinks to redirect the PSU into the Zopa mobile app. The deeplink differs by consent type:
 
 - **AIS:** `zopa://consent-access-request?client_id=<client_id>&response_type=code%20id_token&scope=openid%20accounts&request=<signed_JWT>`
 - **PIS Single Payment:** `zopa://open-banking/pis-single-payment-consent?client_id=<client_id>&response_type=code%20id_token&scope=openid%20payments&request=<signed_JWT>`
 - **PIS Standing Order:** `zopa://open-banking/pis-standing-order-consent?client_id=<client_id>&response_type=code%20id_token&scope=openid%20payments&request=<signed_JWT>`
+
+> **Note:** The `/o3/v1.0/auth-code-url` endpoint is a convenience helper available on sandbox only. It builds the request object server-side using `alg=none` and **must not be used in production** — it does not support PS256 and will return a 500 error if attempted.
 
 ### Request Object JWT
 
@@ -29,7 +25,6 @@ The `request` parameter must be a **PS256-signed JWT** constructed using your re
 The scope must include `openid` in both the deeplink URL and the JWT payload — the value depends on the consent type:
 - AIS: `openid accounts`
 - PIS: `openid payments`
-
 
 **JWT Header:**
 ```json
@@ -95,48 +90,46 @@ The scope must include `openid` in both the deeplink URL and the JWT payload —
 > - Including a `userinfo` claims block or `acr` — these are not required
 
 ## Resource Server URLs
-- Account Information Services API: https://rs1.openbanking.zopa.com/open-banking/v4.0/aisp/**
-- Payment Initiation Services API: https://rs1.openbanking.zopa.com/open-banking/v4.0/pisp/**
+
+- Account Information Services API: `https://rs1.openbanking.zopa.com/open-banking/v4.0/aisp/**`
+- Payment Initiation Services API: `https://rs1.openbanking.zopa.com/open-banking/v4.0/pisp/**`
 
 > **Note for PISPs:** All payment initiation requests must include a detached JWS signature in the `x-jws-signature` header. This is not required for AIS requests. See the [PIS API Overview](/perry/developer/documentation?resource=euhub-zopa-portal&document=docs/API%20Overview/pis.md) for full details.
 
 ## Dynamic Client Registration
 
-Our API allows dynamic client registration in order to create a valid client that is able to use our Authorisation Server. We only trust Software Statement Assertions (SSAs) issued by the Open Banking Directory provided by Open Banking Limited. eIDAS certificates are supported via onboarding to the Open Banking Directory (as discussed in more detail below).
+Our API supports dynamic client registration. We only trust Software Statement Assertions (SSAs) issued by the Open Banking Directory provided by Open Banking Limited. eIDAS certificates are supported via onboarding to the Open Banking Directory.
 
-The url of the registration endpoint is advertised on our OIDC Discovery Endpoints using the registration_endpoint claim.
+The registration endpoint is advertised in the OIDC discovery document via the `registration_endpoint` claim.
 
-The `aud` claim used in the outer JWT of a Dynamic Client Registration request is the Open Banking Limited issued `org_id` (as documented in the Open Banking Limited DCR v3.1 standard).
+The `aud` claim used in the outer JWT of a DCR request is the Open Banking Limited issued `org_id` (as documented in the OBL DCR v3.2 standard).
 
-## Production security profile
-
-As defined further in the Zopa Open Banking API Specification
+## Production Security Profile
 
 - ID Token Signing Algorithm: `PS256`
-- Response Types: `code id_token` — required by FAPI 1.0 Advanced. Sandbox also accepts `code` for ease of testing.
+- Response Types: `code id_token`
 - Request Object Signing Algorithms: `PS256`
 - Token Endpoint Auth Signing Algorithms: `PS256`
 - Token Endpoint Auth Methods: `private_key_jwt`, `tls_client_auth`
 
->For private_key_jwt - the `aud` claim is the url of the token endpoint as specified in OIDC client authentication.
+For `private_key_jwt`, the `aud` claim is the URL of the token endpoint as specified in OIDC client authentication.
 
-> The request object used in OIDC flows the aud claim is the issuer url from the Zopa ASPSP .wellknown endpoint: `https://auth1.openbanking.zopa.com/.well-known/openid-configuration` - though please see above for details of our authorisation URLs which require TPPs to construct deeplinks.
-
-> Note: Our Sandbox API also offers less strict profiles to assist with integration testing.
+For the request object, the `aud` claim is the `issuer` value from the OIDC discovery document (`https://auth1.openbanking.zopa.com`). See the Authorisation URL section above for details on constructing the deeplinks.
 
 ## Certificate Support
 
 ### OB WAC & OB Seal
 
-We support the use of OBWAC and OBSeal on our production and sandbox environments. TPPs can use their QWACs and QSeals to onboard to the OBL directory and generate these certificates.
+We support OBWAC and OBSeal on both production and sandbox. TPPs can use their QWACs and QSeals to onboard to the OBL directory and generate these certificates.
 
 ### QWACs
 
-We support the use of QWACs, but this is not our recommended approach. TPPs facing issues onboarding with QWACs should contact our support desk. Please attach a pem file of the certificate to your support ticket.
+We support QWACs, but this is not our recommended approach. TPPs facing issues onboarding with QWACs should contact our support desk with a PEM file of the certificate attached.
 
 ### QSeal
 
-We support the use of QSeals that have been attached to your software statement in the OB Directory.
+We support QSeals that have been attached to your software statement in the OB Directory.
 
 ## Tokens
-Our refresh tokens last one year, after this TPPs will need to generate a new consent in order to get a new refresh token.
+
+Refresh tokens are valid for one year. After expiry, TPPs will need to generate a new consent to obtain a new refresh token.

--- a/docs/30-production.md
+++ b/docs/30-production.md
@@ -12,7 +12,7 @@ Our production environment conforms to FAPI 1.0 Advanced. Sandbox offers less st
 
 ## Authorisation URL
 
-The authorisation endpoint is the one parameter that cannot be derived from the discovery document. Rather than a standard HTTPS endpoint, we use `zopa://` deeplinks to redirect the PSU into the Zopa mobile app. The deeplink differs by consent type:
+The authorisation endpoint is the one parameter that cannot be derived from the discovery document. Zopa is an app-based bank — PSU authorisation is handled exclusively via the Zopa mobile app, which must be installed on the user's device. Rather than a standard HTTPS endpoint, we use `zopa://` deeplinks to redirect the PSU into the app. The deeplink differs by consent type:
 
 - **AIS:** `zopa://consent-access-request?client_id=<client_id>&response_type=code%20id_token&scope=openid%20accounts&request=<signed_JWT>`
 - **PIS Single Payment:** `zopa://open-banking/pis-single-payment-consent?client_id=<client_id>&response_type=code%20id_token&scope=openid%20payments&request=<signed_JWT>`


### PR DESCRIPTION
- Consolidated OIDC discovery URLs into single top section
- Removed repeated deeplink/non-standard explanation
- Removed duplicated FAPI/sandbox notes between sections
- Tightened wording throughout